### PR TITLE
Fix BFF meta map types after module update

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -7,7 +7,7 @@
                 "nf-core": {
                     "bff": {
                         "branch": "master",
-                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
+                        "git_sha": "5549501d6db037a4872d207635ce329878714408",
                         "installed_by": ["modules"]
                     },
                     "cellsnp/modea": {

--- a/modules/nf-core/bff/meta.yml
+++ b/modules/nf-core/bff/meta.yml
@@ -43,7 +43,7 @@ input:
 output:
   assignment:
     - - meta:
-          type: file
+          type: map
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1' ]`
@@ -56,7 +56,7 @@ output:
             - edam: http://edamontology.org/format_3752
   metrics:
     - - meta:
-          type: file
+          type: map
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1' ]`
@@ -69,7 +69,7 @@ output:
             - edam: http://edamontology.org/format_3752
   params:
     - - meta:
-          type: file
+          type: map
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1' ]`


### PR DESCRIPTION
## Summary
- Correct `meta` output types in `bff/meta.yml` from `file` to `map` after the nf-core BFF module update
- Sync `modules.json` with the updated BFF module git SHA

## Test plan
- [x] Change is metadata-only (`meta.yml` + `modules.json`)
- [ ] CI nf-core lint and nf-test (if triggered for these paths)